### PR TITLE
Look for invalid characters not part of a regex

### DIFF
--- a/vanieth.go
+++ b/vanieth.go
@@ -95,7 +95,15 @@ func main() {
 			// This is a plain prefix matchArg, we don't need a regular expression
 			matcher.Prefix = "0x" + matchArg
 		} else {
-			matcher.Regex = regexp.MustCompile("^0x" + matchArg)
+			// Could be a regex or an invalid character
+			// check we have characters that are part of a regex
+			if strings.ContainsAny(matchArg, "\\.+*[](){,}-:$^!") {
+				matcher.Regex = regexp.MustCompile("^0x" + matchArg)
+			} else {
+				// we have a character that's not part of an Ethereum address
+				fmt.Printf("Error: %s contains an invalid character for an Ethereum address.", matchArg)
+				os.Exit(-1)
+			}
 		}
 	}
 


### PR DESCRIPTION
The search must be either a string part of an ethereum address
or a regular expression.

If we have some characters that can be part of a regular expression
like backslash(\), dot(.), {}, comma(,), etc...
Then we compile the regex and use it.
Otherwise we throw an error because the string cannot match an ethereum address.

It is still possible to search for regexes that cannot match
an Ethereum address like:

[fe]+o , [fe]o, feo[], or feo\n

But _at least_ we reduce the possibility of giving a simple string
like 'feo' that cannot be part of an Ethereum address.

Closes vanieth#3